### PR TITLE
add config option for screen resolution

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ Venus is written and maintained by Alfredo Sequeida and contributors:
 # Patches
 
 Jakob Lindskog
+Aaron Ellington ([@aaronellington](https://github.com/aaronellington))

--- a/AUTHORS
+++ b/AUTHORS
@@ -3,4 +3,4 @@ Venus is written and maintained by Alfredo Sequeida and contributors:
 # Patches
 
 Jakob Lindskog
-Aaron Ellington ([@aaronellington](https://github.com/aaronellington))
+Aaron Ellington

--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ Here is an example that changes the wallpaper every 60 seconds (1 minute):
 WAIT_TIME = 60
 ```
 
+By default a image is requested with the resoluton of your screen. If you need to change that for any reason (if your screen resolution is not available by Unsplash and you are getting a 404 image as your wallpaper), edit the SCREEN_RESOLUTION option. Here is an example:
+
+```
+SCREEN_RESOLUTION = 1920x1080
+```
+
 Venus supports using [pywal](https://github.com/dylanaraps/pywal) as an addon.
 To use pywal first [install it](https://github.com/dylanaraps/pywal/wiki/Installation), 
 then enable it in the config file:

--- a/venus/venus.py
+++ b/venus/venus.py
@@ -58,6 +58,7 @@ def main():
     # getting config
     config = get_config()
     search_term_config = config.get('SETTINGS', 'SEARCH_TERMS', fallback='')
+    screen_resolution_config = config.get('SETTINGS', 'SCREEN_RESOLUTION', fallback='')
     output_path_config = config.get('SETTINGS', 'OUTPUT_PATH', fallback='')
     wait_time_config = config.get('SETTINGS', 'WAIT_TIME', fallback=0)
     use_pywal_config = config.getboolean(
@@ -67,12 +68,16 @@ def main():
     if not output_path_config:
         output_path_config = None
 
+    # default to system screen resolution for empty SCREEN_RESOLUTION setting
+    if not screen_resolution_config:
+        screen_resolution_config = system.get_screen_resolution()
+
     # loop control var
     run = True
 
     while run:
 
-        system.set_wall(get_wall(resolution=system.get_screen_resolution(),
+        system.set_wall(get_wall(resolution=screen_resolution_config,
                                  search_term=search_term_config,
                                  output_path=output_path_config), use_pywal_config)
 


### PR DESCRIPTION
I'm not able to use this tool because of my ultra-wide screens: 2560x1080.

I just get a 404 Unsplash image as my wallpaper:
![venus_rz_7r1y9](https://user-images.githubusercontent.com/7981409/70336311-ee06ed80-1816-11ea-8f76-a5c0ee76d873.jpg)

I'm fine with getting 1920x1080 images and just have them scaled up to fill my screen.

I added an optional config option to override the screen resolution that is sent to Unsplash.

