### PR TITLE
Allow to pass search terms in command

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Windows
 py -m venus 
 ```
 
+You can also supply search terms to the command:
+
+```
+venus landscape nature car
+```
+
 # Config
 Venus can be configured for specific search terms to get a category of images.
 
@@ -69,6 +75,8 @@ Here is an example:
 ```
 SEARCH_TERMS = landscape,nature,car
 ```
+
+Search terms in the command will overwrite those from the config.
 
 By default all images are stored as temporary files in the temp directory of the operating system. To change the location where the images are stored, edit the OUTPUT_PATH option.
 

--- a/venus/venus.py
+++ b/venus/venus.py
@@ -58,7 +58,7 @@ def main():
 
     # getting config
     config = get_config()
-    search_term_config = config.get('SETTINGS', 'SEARCH_TERMS', fallback='')
+    search_term_config = ",".join(sys.argv[1:]) or config.get('SETTINGS', 'SEARCH_TERMS', fallback='')
     screen_resolution_config = config.get('SETTINGS', 'SCREEN_RESOLUTION', fallback='')
     output_path_config = config.get('SETTINGS', 'OUTPUT_PATH', fallback='')
     wait_time_config = config.get('SETTINGS', 'WAIT_TIME', fallback=0)


### PR DESCRIPTION
This PR allows to use the command `venus cars hills`, which will search for those terms, overwriting anything that is specified in the config. If nothing is supplied everything stays as before. This is helpful when using venus interactively and not via a cronjob. Thanks for considering this change.